### PR TITLE
Fix monitor sorting

### DIFF
--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -88,7 +88,7 @@ $j( function() {
 function applySort(event, ui) {
   var monitor_ids = $j(this).sortable('toArray');
   var ajax = new Request.JSON( {
-      url: '/index.php?request=console',
+      url: 'index.php?request=console',
       data: { monitor_ids: monitor_ids, action: 'sort' },
       method: 'post',
       timeout: AJAX_TIMEOUT


### PR DESCRIPTION
Fixed issue #2014

The AJAX request to update the monitor sorting goes to /index.php, which doesn't exist.  This modifies it to go to index.php (which results in going to /zm/index.php).